### PR TITLE
修复replaceAll函数未定义的bug

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -80,12 +80,12 @@ async function createServer({
 
   const homePage = await fs.readFile(path.resolve(__dirname, 'paintBoard.html'))
     .then((data) => data.toString()
-      .replace(new RegExp(/(\$wsUrl)/g), wsUrl)
-      .replace(new RegExp(/(\$width)/g), width)
-      .replace(new RegExp(/(\$height)/g), height)
-      .replace(new RegExp(/(\$5width)/g), 5 * width)
-      .replace(new RegExp(/(\$5height)/g), 5 * height)
-      .replace(new RegExp(/(\$cd)/g), cd));
+      .replace(/\$wsUrl/g, wsUrl)
+      .replace(/\$width/g, width)
+      .replace(/\$height/g, height)
+      .replace(/\$5width/g, 5 * width)
+      .replace(/\$5height/g, 5 * height)
+      .replace(/\$cd/g, cd));
 
   const wss = await new Promise((resolve, reject) => {
     const wsServer = new WebSocket.Server({ port: wsport, path: '/ws' });

--- a/lib.js
+++ b/lib.js
@@ -80,12 +80,12 @@ async function createServer({
 
   const homePage = await fs.readFile(path.resolve(__dirname, 'paintBoard.html'))
     .then((data) => data.toString()
-      .replaceAll('$wsUrl', wsUrl)
-      .replaceAll('$width', width)
-      .replaceAll('$height', height)
-      .replaceAll('$5width', 5 * width)
-      .replaceAll('$5height', 5 * height)
-      .replaceAll('$cd', cd));
+      .replace(new RegExp(/(\$wsUrl)/g), wsUrl)
+      .replace(new RegExp(/(\$width)/g), width)
+      .replace(new RegExp(/(\$height)/g), height)
+      .replace(new RegExp(/(\$5width)/g), 5 * width)
+      .replace(new RegExp(/(\$5height)/g), 5 * height)
+      .replace(new RegExp(/(\$cd)/g), cd));
 
   const wss = await new Promise((resolve, reject) => {
     const wsServer = new WebSocket.Server({ port: wsport, path: '/ws' });


### PR DESCRIPTION
在我所使用的Node.js环境上，字符串类型未定义```replaceAll```函数，直接运行会出现以下错误：
```
(node:3964) UnhandledPromiseRejectionWarning: TypeError: data.toString(...).replaceAll is not a function
    at D:\zhengfourth\node-v14.3.0-win-x64\node_modules\fake-luogu-paintboard-server\lib.js:83:8
    at async createServer (D:\zhengfourth\node-v14.3.0-win-x64\node_modules\fake-luogu-paintboard-server\lib.js:81:20)
```
修复方法：用```replace```函数和正则表达式代替```replaceAll```的功能。